### PR TITLE
Add node clicked shiny input event option

### DIFF
--- a/R/collapsibleTree.R
+++ b/R/collapsibleTree.R
@@ -13,6 +13,8 @@
 #' @param inputId the input slot that will be used to access the selected node (for Shiny).
 #' Will return a named list of the most recently clicked node,
 #' along with all of its parents.
+#' @param inputClickedId the input slot that will be used to access node click event (for Shiny).
+#' Will return the number of clicked nodes.
 #' @param attribute numeric column not listed in hierarchy that will be used
 #' for tooltips, if applicable. Defaults to 'leafCount',
 #' which is the cumulative count of a node's children
@@ -115,7 +117,8 @@
 #' @importFrom stats complete.cases median
 #' @rdname collapsibleTree
 #' @export
-collapsibleTree <- function(df, ..., inputId = NULL, attribute = "leafCount",
+collapsibleTree <- function(df, ..., inputId = NULL, inputClickedId = NULL,
+                            attribute = "leafCount",
                             aggFun = sum, fill = "lightsteelblue",
                             linkLength = NULL, fontSize = 10, tooltip = FALSE,
                             tooltipHtml = NULL,nodeSize = NULL, collapsed = TRUE,

--- a/R/collapsibleTree.data.frame.R
+++ b/R/collapsibleTree.data.frame.R
@@ -2,7 +2,8 @@
 #' @method collapsibleTree data.frame
 #' @export
 collapsibleTree.data.frame <- function(df, hierarchy, root = deparse(substitute(df)),
-                                       inputId = NULL, attribute = "leafCount",
+                                       inputId = NULL, inputClickedId = NULL,
+                                       attribute = "leafCount",
                                        aggFun = sum, fill = "lightsteelblue",
                                        fillByLevel = TRUE, linkLength = NULL, fontSize = 10,
                                        tooltip = FALSE, nodeSize = NULL, collapsed = TRUE,
@@ -42,6 +43,7 @@ collapsibleTree.data.frame <- function(df, hierarchy, root = deparse(substitute(
   options <- list(
     hierarchy = hierarchy,
     input = inputId,
+    inputClicked = inputClickedId,
     attribute = attribute,
     linkLength = linkLength,
     fontSize = fontSize,

--- a/R/collapsibleTree.data.tree.R
+++ b/R/collapsibleTree.data.tree.R
@@ -2,7 +2,8 @@
 #' @method collapsibleTree Node
 #' @export
 collapsibleTree.Node <- function(df, hierarchy_attribute = "level",
-                                 root = df$name, inputId = NULL, attribute = "leafCount",
+                                 root = df$name, inputId = NULL,
+                                 inputClickedId = NULL, attribute = "leafCount",
                                  aggFun = sum, fill = "lightsteelblue",
                                  linkLength = NULL, fontSize = 10, tooltip = FALSE,
                                  tooltipHtml = NULL,nodeSize = NULL, collapsed = TRUE,
@@ -31,6 +32,7 @@ collapsibleTree.Node <- function(df, hierarchy_attribute = "level",
   options <- list(
     hierarchy = hierarchy,
     input = inputId,
+    inputClicked = inputClickedId,
     attribute = attribute,
     linkLength = linkLength,
     fontSize = fontSize,

--- a/R/collapsibleTreeNetwork.R
+++ b/R/collapsibleTreeNetwork.R
@@ -19,6 +19,8 @@
 #' Will return a named list of the most recently clicked node,
 #' along with all of its parents.
 #' (For \code{collapsibleTreeNetwork} the names of the list are tree depth)
+#' @param inputClickedId the input slot that will be used to access node click event (for Shiny).
+#' Will return the number of clicked nodes.
 #' @param attribute numeric column not listed in hierarchy that will be used
 #' as weighting to define the color gradient across nodes. Defaults to 'leafCount',
 #' which colors nodes by the cumulative count of its children
@@ -97,7 +99,8 @@
 #' @importFrom data.tree ToListExplicit FromDataFrameNetwork
 #' @importFrom data.tree Traverse Do Aggregate
 #' @export
-collapsibleTreeNetwork <- function(df, inputId = NULL, attribute = "leafCount",
+collapsibleTreeNetwork <- function(df, inputId = NULL,  inputClickedId = NULL,
+                                    attribute = "leafCount",
                                     aggFun = sum, fill = "lightsteelblue",
                                     linkLength = NULL, fontSize = 10, tooltip = TRUE,
                                     tooltipHtml = NULL, nodeSize = NULL, collapsed = TRUE,
@@ -146,6 +149,7 @@ collapsibleTreeNetwork <- function(df, inputId = NULL, attribute = "leafCount",
   options <- list(
     hierarchy = 1:node$height,
     input = inputId,
+    inputClicked = inputClickedId,
     attribute = attribute,
     linkLength = linkLength,
     fontSize = fontSize,

--- a/R/collapsibleTreeSummary.R
+++ b/R/collapsibleTreeSummary.R
@@ -13,6 +13,8 @@
 #' @param inputId the input slot that will be used to access the selected node (for Shiny).
 #' Will return a named list of the most recently clicked node,
 #' along with all of its parents.
+#' @param inputClickedId the input slot that will be used to access node click event (for Shiny).
+#' Will return the number of clicked nodes.
 #' @param attribute numeric column not listed in hierarchy that will be used
 #' as weighting to define the color gradient across nodes. Defaults to 'leafCount',
 #' which colors nodes by the cumulative count of its children
@@ -63,7 +65,8 @@
 #' @importFrom stats complete.cases
 #' @export
 collapsibleTreeSummary <- function(df, hierarchy, root = deparse(substitute(df)),
-                                    inputId = NULL, attribute = "leafCount",
+                                    inputId = NULL,  inputClickedId = NULL,
+                                    attribute = "leafCount",
                                     fillFun = colorspace::heat_hcl, maxPercent = 25,
                                     percentOfParent = FALSE, linkLength = NULL,
                                     fontSize = 10, tooltip = TRUE, nodeSize = NULL,
@@ -103,6 +106,7 @@ collapsibleTreeSummary <- function(df, hierarchy, root = deparse(substitute(df))
   options <- list(
     hierarchy = hierarchy,
     input = inputId,
+    inputClicked = inputClickedId,
     attribute = attribute,
     linkLength = linkLength,
     fontSize = fontSize,

--- a/inst/htmlwidgets/collapsibleTree.js
+++ b/inst/htmlwidgets/collapsibleTree.js
@@ -9,6 +9,7 @@ HTMLWidgets.widget({
     duration = 750,
     root = {},
     options = {},
+    nodesClicked = 0,
     treemap;
 
     // Optionally enable zooming, and limit to 1/5x or 5x of the original viewport
@@ -184,6 +185,9 @@ HTMLWidgets.widget({
 
       // Toggle children on click.
       function click(d) {
+        if (options.inputClicked) {
+          Shiny.setInputValue(options.inputClicked, ++nodesClicked);
+        }
         if (d.children) {
           d._children = d.children;
           d.children = null;

--- a/man/collapsibleTree.Rd
+++ b/man/collapsibleTree.Rd
@@ -12,25 +12,26 @@ Christopher Gandrud: \url{http://christophergandrud.github.io/networkD3/}.
 d3noob: \url{https://bl.ocks.org/d3noob/43a860bc0024792f8803bba8ca0d5ecd}.
 }
 \usage{
-collapsibleTree(df, ..., inputId = NULL, attribute = "leafCount",
-  aggFun = sum, fill = "lightsteelblue", linkLength = NULL,
-  fontSize = 10, tooltip = FALSE, tooltipHtml = NULL,
-  nodeSize = NULL, collapsed = TRUE, zoomable = TRUE, width = NULL,
-  height = NULL)
+collapsibleTree(df, ..., inputId = NULL, inputClickedId = NULL,
+  attribute = "leafCount", aggFun = sum, fill = "lightsteelblue",
+  linkLength = NULL, fontSize = 10, tooltip = FALSE,
+  tooltipHtml = NULL, nodeSize = NULL, collapsed = TRUE,
+  zoomable = TRUE, width = NULL, height = NULL)
 
 \method{collapsibleTree}{data.frame}(df, hierarchy,
   root = deparse(substitute(df)), inputId = NULL,
-  attribute = "leafCount", aggFun = sum, fill = "lightsteelblue",
-  fillByLevel = TRUE, linkLength = NULL, fontSize = 10,
-  tooltip = FALSE, nodeSize = NULL, collapsed = TRUE,
-  zoomable = TRUE, width = NULL, height = NULL, ...)
+  inputClickedId = NULL, attribute = "leafCount", aggFun = sum,
+  fill = "lightsteelblue", fillByLevel = TRUE, linkLength = NULL,
+  fontSize = 10, tooltip = FALSE, nodeSize = NULL,
+  collapsed = TRUE, zoomable = TRUE, width = NULL, height = NULL,
+  ...)
 
 \method{collapsibleTree}{Node}(df, hierarchy_attribute = "level",
-  root = df$name, inputId = NULL, attribute = "leafCount",
-  aggFun = sum, fill = "lightsteelblue", linkLength = NULL,
-  fontSize = 10, tooltip = FALSE, tooltipHtml = NULL,
-  nodeSize = NULL, collapsed = TRUE, zoomable = TRUE, width = NULL,
-  height = NULL, ...)
+  root = df$name, inputId = NULL, inputClickedId = NULL,
+  attribute = "leafCount", aggFun = sum, fill = "lightsteelblue",
+  linkLength = NULL, fontSize = 10, tooltip = FALSE,
+  tooltipHtml = NULL, nodeSize = NULL, collapsed = TRUE,
+  zoomable = TRUE, width = NULL, height = NULL, ...)
 }
 \arguments{
 \item{df}{a \code{data.frame} from which to construct a nested list
@@ -42,6 +43,9 @@ this generic function - \code{collapsibleTree.data.frame}, \code{collapsibleTree
 \item{inputId}{the input slot that will be used to access the selected node (for Shiny).
 Will return a named list of the most recently clicked node,
 along with all of its parents.}
+
+\item{inputClickedId}{the input slot that will be used to access node click event (for Shiny).
+Will return the number of clicked nodes.}
 
 \item{attribute}{numeric column not listed in hierarchy that will be used
 for tooltips, if applicable. Defaults to 'leafCount',

--- a/man/collapsibleTreeNetwork.Rd
+++ b/man/collapsibleTreeNetwork.Rd
@@ -9,11 +9,11 @@ Christopher Gandrud: \url{http://christophergandrud.github.io/networkD3/}.
 d3noob: \url{https://bl.ocks.org/d3noob/43a860bc0024792f8803bba8ca0d5ecd}.
 }
 \usage{
-collapsibleTreeNetwork(df, inputId = NULL, attribute = "leafCount",
-  aggFun = sum, fill = "lightsteelblue", linkLength = NULL,
-  fontSize = 10, tooltip = TRUE, tooltipHtml = NULL,
-  nodeSize = NULL, collapsed = TRUE, zoomable = TRUE, width = NULL,
-  height = NULL)
+collapsibleTreeNetwork(df, inputId = NULL, inputClickedId = NULL,
+  attribute = "leafCount", aggFun = sum, fill = "lightsteelblue",
+  linkLength = NULL, fontSize = 10, tooltip = TRUE,
+  tooltipHtml = NULL, nodeSize = NULL, collapsed = TRUE,
+  zoomable = TRUE, width = NULL, height = NULL)
 }
 \arguments{
 \item{df}{a network data frame (where every row is a node)
@@ -29,6 +29,9 @@ from which to construct a nested list
 Will return a named list of the most recently clicked node,
 along with all of its parents.
 (For \code{collapsibleTreeNetwork} the names of the list are tree depth)}
+
+\item{inputClickedId}{the input slot that will be used to access node click event (for Shiny).
+Will return the number of clicked nodes.}
 
 \item{attribute}{numeric column not listed in hierarchy that will be used
 as weighting to define the color gradient across nodes. Defaults to 'leafCount',

--- a/man/collapsibleTreeSummary.Rd
+++ b/man/collapsibleTreeSummary.Rd
@@ -10,7 +10,7 @@ d3noob: \url{https://bl.ocks.org/d3noob/43a860bc0024792f8803bba8ca0d5ecd}.
 }
 \usage{
 collapsibleTreeSummary(df, hierarchy, root = deparse(substitute(df)),
-  inputId = NULL, attribute = "leafCount",
+  inputId = NULL, inputClickedId = NULL, attribute = "leafCount",
   fillFun = colorspace::heat_hcl, maxPercent = 25,
   percentOfParent = FALSE, linkLength = NULL, fontSize = 10,
   tooltip = TRUE, nodeSize = NULL, collapsed = TRUE,
@@ -27,6 +27,9 @@ and hierarchy of the tree network}
 \item{inputId}{the input slot that will be used to access the selected node (for Shiny).
 Will return a named list of the most recently clicked node,
 along with all of its parents.}
+
+\item{inputClickedId}{the input slot that will be used to access node click event (for Shiny).
+Will return the number of clicked nodes.}
 
 \item{attribute}{numeric column not listed in hierarchy that will be used
 as weighting to define the color gradient across nodes. Defaults to 'leafCount',


### PR DESCRIPTION
This pull request adds a new Shiny input slot, whose value changes each time a node is clicked. I am currently using `collapsibleTree` in a project where I need to know if a node has been clicked twice in a row. With the current node clicked input the value doesn't change if the same node is clicked twice.

Thanks !