### PR TITLE
use Node$attributes instead of deprecated Node$fields [#59]

### DIFF
--- a/R/collapsibleTree.data.tree.R
+++ b/R/collapsibleTree.data.tree.R
@@ -14,9 +14,9 @@ collapsibleTree.Node <- function(df, hierarchy_attribute = "level",
   # reject bad inputs
   if(!is(df) %in% "Node") stop("df must be a data tree object")
   if(!is.character(fill)) stop("fill must be a either a color or column name")
-  if(is.character(collapsed) & !(collapsed %in% c(df$fields, nodeAttr))) stop("collapsed column name is incorrect")
-  if(!is.null(tooltipHtml)) if(!(tooltipHtml %in% df$fields)) stop("tooltipHtml column name is incorrect")
-  if(!is.null(nodeSize)) if(!(nodeSize %in% c(df$fields, nodeAttr))) stop("nodeSize column name is incorrect")
+  if(is.character(collapsed) & !(collapsed %in% c(df$attributes, nodeAttr))) stop("collapsed column name is incorrect")
+  if(!is.null(tooltipHtml)) if(!(tooltipHtml %in% df$attributes)) stop("tooltipHtml column name is incorrect")
+  if(!is.null(nodeSize)) if(!(nodeSize %in% c(df$attributes, nodeAttr))) stop("nodeSize column name is incorrect")
 
   # calculate the right and left margins in pixels
   leftMargin <- nchar(root)
@@ -48,7 +48,7 @@ collapsibleTree.Node <- function(df, hierarchy_attribute = "level",
   # these are the fields that will ultimately end up in the json
   jsonFields <- NULL
 
-  if(fill %in% df$fields) {
+  if(fill %in% df$attributes) {
     # fill in node colors based on column name
     df$Do(function(x) x$fill <- x[[fill]])
     jsonFields <- c(jsonFields, "fill")


### PR DESCRIPTION
Reprex from `data.tree` vignette [portfolio example](https://cran.r-project.org/web/packages/data.tree/vignettes/applications.html#convert-from-data.frame-1):

```
fileName <- system.file("extdata", "portfolio.csv", package="data.tree")
pfodf <- read.csv(fileName, stringsAsFactors = FALSE)
pfodf$pathString <- paste("portfolio",
  pfodf$AssetCategory,
  pfodf$AssetClass,
  pfodf$SubAssetClass,
  pfodf$ISIN,
  sep = "/")
pfo <- as.Node(pfodf)
```

Before:
```
> collapsibleTree(pfo)
[1] "Node$fields will be deprecated in the next release. Please use Node$attributes instead."
[1] "Node$fields will be deprecated in the next release. Please use Node$attributes instead."
```

After:
```
> collapsibleTree(pfo)
>
```

Closes #59 
